### PR TITLE
BF: typo fixed in angularFire.Firebase type annotation

### DIFF
--- a/angularfire-externs.js
+++ b/angularfire-externs.js
@@ -51,13 +51,13 @@ angularFire.FirebaseObject.prototype.$value;
 
 
 /**
- * @return {!angular.$q.Promise.<!angularFire.Firebase>}
+ * @return {!angular.$q.Promise.<!angularFire.FirebaseObject>}
  */
 angularFire.FirebaseObject.prototype.$remove = function () {};
 
 
 /**
- * @return {!angular.$q.Promise.<!angularFire.Firebase>}
+ * @return {!angular.$q.Promise.<!angularFire.FirebaseObject>}
  */
 angularFire.FirebaseObject.prototype.$save = function () {};
 


### PR DESCRIPTION
On lines 54 and 60 I've got: WARNING - Bad type annotation. Unknown type angularFire.Firebase
I guess it was just a typo.
